### PR TITLE
before loaded all tasks.

### DIFF
--- a/lib/rake_shared_context.rb
+++ b/lib/rake_shared_context.rb
@@ -15,8 +15,8 @@ begin
 
     before do
       Rake.application = rake
-      Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
-
+      rake.init
+      rake.load_rakefile
       Rake::Task.define_task(:environment)
     end
   end


### PR DESCRIPTION
describeに指定したrake taskだけでなく予め全てのtaskをロードしてはどうでしょうか？
起動は遅くなるかもしれませんが、テストの中で他のrake taskを簡単に呼び出すことができます。

``` ruby
describe 'batch:execute' do
  before do
    rake['procedure_setup'].invoke
  end
  it
end
```
