### PR TITLE
All the tasks are loaded before execution.

### DIFF
--- a/lib/rake_shared_context.rb
+++ b/lib/rake_shared_context.rb
@@ -15,8 +15,10 @@ begin
 
     before do
       Rake.application = rake
-      Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
-
+      Dir::glob("lib/tasks/*.rake").each do |task|
+        Rake.application.rake_require(task.sub(/.rake$/,''), [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+      end
+       
       Rake::Task.define_task(:environment)
     end
   end


### PR DESCRIPTION
再プルリクします。
describeに指定したrake taskだけでなく予め全てのtaskをロードしてはどうでしょうか？
起動は遅くなるかもしれませんが、テストの中で他のrake taskを簡単に呼び出すことができます。

``` ruby
describe 'batch:execute' do
  before do
    rake['procedure_setup'].invoke
  end
  it
end
```
