### PR TITLE
🐛 sort rake file load order

### DIFF
--- a/lib/rake_shared_context.rb
+++ b/lib/rake_shared_context.rb
@@ -46,7 +46,7 @@ begin
       rake_dir = RakeSharedContext.rake_dir
       rake_files = File.join(rake_dir, "**", "*.rake")
 
-      Dir.glob(rake_files).each do |task|
+      Dir.glob(rake_files).sort.each do |task|
         filename_without_ext = File.basename(task.sub(/.rake$/, ''))
         Rake.application.rake_require(filename_without_ext, [File.dirname(task).to_s], loaded_files)
       end


### PR DESCRIPTION
Dir.glob return file list, but these order depend on filesystem, so the order isn't a constant.
The rake_require method load .rake file but if already load same name rake file, after one will skip.

But, there is a possibility that the first load file will change, because Dir.glob return value's order isn't constant.
This cause environment dependence test failed, because loaded will change on other environment.

In the rails, they sort file paths before load rake files.
https://github.com/rails/rails/blob/master/railties/lib/rails/engine.rb#L654

We should sort file paths before load rake files too.